### PR TITLE
Use `data.aws_region.current.region` for ARNs and add AWS provider constraint

### DIFF
--- a/.github/workflows/test-apply-and-release.yaml
+++ b/.github/workflows/test-apply-and-release.yaml
@@ -5,14 +5,16 @@ on:
     branches: [acc]
 
 jobs:
-  tests-apply:
-    uses: guidion-digital/terrappy/.github/workflows/tfc-test-helper-module-apply.yaml@v1
-    with:
-      environment_name: "localstack"
+  tests-terraform:
+    uses: guidion-digital/terrappy/.github/workflows/tfc-test-basic.yaml@v1
+    permissions:
+      contents: read
+      pull-requests: write
+
 
   workflow-change:
-    if: ${{ needs.tests-apply.outputs.local-stack-apply-result != 'success' && needs.tests-apply.outputs.terraform-file-changes-result == 'false' }}
-    needs: tests-apply
+    if: ${{ needs.tests-terraform.outputs.terraform-validate-result != 'success' && needs.tests-terraform.outputs.terraform-lint-result != 'success' && needs.tests-terraform.outputs.terraform-file-changes-result == 'false' }}
+    needs: tests-terraform
     uses: guidion-digital/release-workflows/.github/workflows/github-merge-into-master.yaml@v2
     with:
       branch: ${{ github.ref_name }}
@@ -21,8 +23,8 @@ jobs:
 
   # Merges acc into master and release new tag for the module because a change to Terraform code has been made.
   terraform-module-change:
-    if: ${{ needs.tests-apply.outputs.local-stack-apply-result == 'success' }}
-    needs: tests-apply
+    if: ${{ needs.tests-terraform.outputs.terraform-validate-result == 'success' && needs.tests-terraform.outputs.terraform-lint-result == 'success' }}
+    needs: tests-terraform
     uses: guidion-digital/release-workflows/.github/workflows/github-merge-into-master.yaml@v2
     with:
       branch: ${{ github.ref_name }}
@@ -30,8 +32,8 @@ jobs:
       contents: write
 
   release-module-version:
-    if: ${{ needs.tests-apply.outputs.local-stack-apply-result == 'success' }}
-    needs: [tests-apply, terraform-module-change]
+    if: ${{ needs.tests-terraform.outputs.terraform-validate-result == 'success' && needs.tests-terraform.outputs.terraform-lint-result == 'success' }}
+    needs: [tests-terraform, terraform-module-change]
     uses: guidion-digital/release-workflows/.github/workflows/github-release-tag.yaml@v2
     with:
       branch: ${{ github.ref_name }}

--- a/.github/workflows/test-apply-and-release.yaml
+++ b/.github/workflows/test-apply-and-release.yaml
@@ -1,41 +1,16 @@
-name: Tests applies and releases new version
+name: Release new version of examples pass
 
 on:
   push:
     branches: [acc]
 
 jobs:
-  tests-terraform:
-    uses: guidion-digital/terrappy/.github/workflows/tfc-test-basic.yaml@v1
-    permissions:
-      contents: read
-      pull-requests: write
+  test-and-release:
+    concurrency:
+      group: "acc"
+      cancel-in-progress: false
 
-
-  workflow-change:
-    if: ${{ needs.tests-terraform.outputs.terraform-validate-result != 'success' && needs.tests-terraform.outputs.terraform-lint-result != 'success' && needs.tests-terraform.outputs.terraform-file-changes-result == 'false' }}
-    needs: tests-terraform
-    uses: guidion-digital/release-workflows/.github/workflows/github-merge-into-master.yaml@v2
-    with:
-      branch: ${{ github.ref_name }}
+    uses: guidion-digital/terrappy/.github/workflows/tf-module-releaser.yaml@v2
     permissions:
       contents: write
-
-  # Merges acc into master and release new tag for the module because a change to Terraform code has been made.
-  terraform-module-change:
-    if: ${{ needs.tests-terraform.outputs.terraform-validate-result == 'success' && needs.tests-terraform.outputs.terraform-lint-result == 'success' }}
-    needs: tests-terraform
-    uses: guidion-digital/release-workflows/.github/workflows/github-merge-into-master.yaml@v2
-    with:
-      branch: ${{ github.ref_name }}
-    permissions:
-      contents: write
-
-  release-module-version:
-    if: ${{ needs.tests-terraform.outputs.terraform-validate-result == 'success' && needs.tests-terraform.outputs.terraform-lint-result == 'success' }}
-    needs: [tests-terraform, terraform-module-change]
-    uses: guidion-digital/release-workflows/.github/workflows/github-release-tag.yaml@v2
-    with:
-      branch: ${{ github.ref_name }}
-    permissions:
-      contents: write
+    secrets: inherit

--- a/.github/workflows/test-plan.yaml
+++ b/.github/workflows/test-plan.yaml
@@ -6,21 +6,12 @@ on:
     types: [opened, edited, synchronize]
 
 jobs:
-  test-workflow:
-    uses: guidion-digital/release-workflows/.github/workflows/github-test-workflow.yaml@v2
-    permissions:
-      pull-requests: write
-      contents: read
-
-  tests-terraform:
-    needs: test-workflow
-    uses: guidion-digital/terrappy/.github/workflows/tfc-test-basic.yaml@v1
+  tests-plan:
+    concurrency:
+      group: "acc"
+      cancel-in-progress: false
+    uses: guidion-digital/terrappy/.github/workflows/tf-module-pr-planner.yaml@v2
     permissions:
       contents: read
       pull-requests: write
-
-  release-dry-run:
-    needs: [test-workflow, tests-terraform]
-    uses: guidion-digital/release-workflows/.github/workflows/github-release-tag-dry-run.yaml@v2
-    with:
-      branch: ${{ github.ref_name }}
+    secrets: inherit

--- a/.github/workflows/test-plan.yaml
+++ b/.github/workflows/test-plan.yaml
@@ -12,15 +12,15 @@ jobs:
       pull-requests: write
       contents: read
 
-  tests-plan:
+  tests-terraform:
     needs: test-workflow
-    uses: guidion-digital/terrappy/.github/workflows/tfc-test-helper-module-plan.yaml@v1
+    uses: guidion-digital/terrappy/.github/workflows/tfc-test-basic.yaml@v1
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
 
   release-dry-run:
-    needs: tests-plan
+    needs: [test-workflow, tests-terraform]
     uses: guidion-digital/release-workflows/.github/workflows/github-release-tag-dry-run.yaml@v2
     with:
       branch: ${{ github.ref_name }}

--- a/api_app.tf
+++ b/api_app.tf
@@ -57,7 +57,7 @@ data "aws_iam_policy_document" "api0" {
   statement {
     sid       = "waf2"
     effect    = "Allow"
-    resources = ["arn:aws:wafv2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:regional/webacl/*/*"]
+    resources = ["arn:aws:wafv2:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:regional/webacl/*/*"]
     actions   = ["wafv2:GetWebACLForResource"]
   }
 
@@ -160,9 +160,9 @@ data "aws_iam_policy_document" "api0" {
     sid    = "logs0"
     effect = "Allow"
     resources = [
-      "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/${var.application_name}-*",
-      "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:/aws/rds/proxy/${var.application_name}-*",
-      "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:/aws/rds/${var.application_name}-*:log-stream:*"
+      "arn:aws:logs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/${var.application_name}-*",
+      "arn:aws:logs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/rds/proxy/${var.application_name}-*",
+      "arn:aws:logs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/rds/${var.application_name}-*:log-stream:*"
     ]
     actions = [
       "logs:DescribeSubscriptionFilters",
@@ -221,7 +221,7 @@ data "aws_iam_policy_document" "api1" {
     sid    = "appscalingread0"
     effect = "Allow"
     resources = [
-      "arn:aws:application-autoscaling:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:scalable-target/*"
+      "arn:aws:application-autoscaling:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:scalable-target/*"
     ]
     actions = [
       "application-autoscaling:DescribeScalableTargets",
@@ -236,7 +236,7 @@ data "aws_iam_policy_document" "api1" {
     effect = "Allow"
     # FIXME: We need to scope this down
     resources = [
-      "arn:aws:application-autoscaling:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:scalable-target/*"
+      "arn:aws:application-autoscaling:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:scalable-target/*"
     ]
     actions = [
       "application-autoscaling:RegisterScalableTarget",
@@ -290,7 +290,7 @@ data "aws_iam_policy_document" "api2" {
   statement {
     sid       = "secrets0"
     effect    = "Allow"
-    resources = ["arn:aws:secretsmanager:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:secret:api-keys/${var.application_name}/*"]
+    resources = ["arn:aws:secretsmanager:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:secret:api-keys/${var.application_name}/*"]
     actions = [
       "secretsmanager:PutSecretValue",
       "secretsmanager:PutResourcePolicy",
@@ -309,7 +309,7 @@ data "aws_iam_policy_document" "api2" {
     effect = "Allow"
     resources = [
       "arn:aws:lambda:*:${data.aws_caller_identity.current.account_id}:function:${var.application_name}-*",
-      "arn:aws:lambda:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:event-source-mapping:*"
+      "arn:aws:lambda:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:event-source-mapping:*"
     ]
     actions = [
       "lambda:DeleteFunctionConcurrency",
@@ -415,12 +415,12 @@ data "aws_iam_policy_document" "api2" {
     actions = ["rds:*"]
 
     resources = [
-      "arn:aws:rds:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:subgrp:${var.application_name}*",
-      "arn:aws:rds:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:db:${var.application_name}*",
-      "arn:aws:rds:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:pg:${var.application_name}*",
-      "arn:aws:rds:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:db-proxy:${var.application_name}*",
-      "arn:aws:rds:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:og:${var.application_name}*",
-      "arn:aws:rds:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:snapshot:${var.application_name}*"
+      "arn:aws:rds:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:subgrp:${var.application_name}*",
+      "arn:aws:rds:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:db:${var.application_name}*",
+      "arn:aws:rds:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:pg:${var.application_name}*",
+      "arn:aws:rds:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:db-proxy:${var.application_name}*",
+      "arn:aws:rds:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:og:${var.application_name}*",
+      "arn:aws:rds:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:snapshot:${var.application_name}*"
     ]
   }
 
@@ -432,7 +432,7 @@ data "aws_iam_policy_document" "api2" {
     ]
 
     resources = [
-      "arn:aws:rds:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:db:*"
+      "arn:aws:rds:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:db:*"
     ]
   }
 
@@ -473,10 +473,10 @@ data "aws_iam_policy_document" "api2" {
     ]
 
     resources = [
-      "arn:aws:rds:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:db-proxy:*",
-      "arn:aws:rds:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:db-proxy-endpoint:*",
-      "arn:aws:rds:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:db-proxy-target-group:*",
-      "arn:aws:rds:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:target-group:*"
+      "arn:aws:rds:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:db-proxy:*",
+      "arn:aws:rds:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:db-proxy-endpoint:*",
+      "arn:aws:rds:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:db-proxy-target-group:*",
+      "arn:aws:rds:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:target-group:*"
     ]
   }
 

--- a/api_app.tf
+++ b/api_app.tf
@@ -152,7 +152,7 @@ data "aws_iam_policy_document" "api0" {
   statement {
     sid       = "sts0"
     effect    = "Allow"
-    resources = ["${var.domain_account_role}"]
+    resources = [var.domain_account_role]
     actions   = ["sts:AssumeRole"]
   }
 
@@ -194,7 +194,7 @@ data "aws_iam_policy_document" "api0" {
   statement {
     sid       = "serviceroles"
     effect    = "Allow"
-    resources = ["${var.application_role_arn}"]
+    resources = [var.application_role_arn]
     actions = [
       "iam:CreateServiceLinkedRole",
       "iam:DeleteServiceLinkedRole",

--- a/cdn_app.tf
+++ b/cdn_app.tf
@@ -203,7 +203,7 @@ data "aws_iam_policy_document" "cdn2" {
   statement {
     sid       = "waf2"
     effect    = "Allow"
-    resources = ["arn:aws:wafv2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:regional/webacl/*/*"]
+    resources = ["arn:aws:wafv2:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:regional/webacl/*/*"]
     actions   = ["wafv2:GetWebACLForResource"]
   }
 

--- a/cdn_app.tf
+++ b/cdn_app.tf
@@ -106,7 +106,7 @@ data "aws_iam_policy_document" "cdn0" {
   statement {
     sid       = "serviceroles"
     effect    = "Allow"
-    resources = ["${var.application_role_arn}"]
+    resources = [var.application_role_arn]
 
     actions = [
       "iam:CreateServiceLinkedRole",
@@ -140,7 +140,7 @@ data "aws_iam_policy_document" "cdn1" {
   statement {
     sid       = "sts"
     effect    = "Allow"
-    resources = ["${var.domain_account_role}"]
+    resources = [var.domain_account_role]
     actions   = ["sts:AssumeRole"]
   }
 

--- a/common.tf
+++ b/common.tf
@@ -148,7 +148,7 @@ data "aws_iam_policy_document" "elasticache" {
   statement {
     sid       = "elasticachecrud0"
     effect    = "Allow"
-    resources = ["arn:aws:elasticache:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:cluster:${var.application_name}-*"]
+    resources = ["arn:aws:elasticache:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:cluster:${var.application_name}-*"]
     actions = [
       "elasticache:RemoveTagsFromResource",
       "elasticache:DeleteCacheCluster",
@@ -163,20 +163,20 @@ data "aws_iam_policy_document" "elasticache" {
     sid    = "cacheresrouces0"
     effect = "Allow"
     resources = [
-      "arn:aws:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:security-group/applications/${var.application_name}/*",
-      "arn:aws:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:subnet/applications/${var.application_name}/*",
-      "arn:aws:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:network-interface/applications/${var.application_name}/*",
-      "arn:aws:elasticache:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:cluster:/applications/${var.application_name}/*",
-      "arn:aws:elasticache:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:serverlesscache:/applications/${var.application_name}/*",
-      "arn:aws:elasticache:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parametergroup:${var.application_name}-*",
-      "arn:aws:elasticache:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:serverlesscachesnapshot:/applications/${var.application_name}/*",
-      "arn:aws:elasticache:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:reserved-instance:/applications/${var.application_name}/*",
-      "arn:aws:elasticache:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:user:/applications/${var.application_name}/*",
-      "arn:aws:elasticache:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:securitygroup:/applications/${var.application_name}/*",
-      "arn:aws:elasticache:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:replicationgroup:/applications/${var.application_name}/*",
-      "arn:aws:elasticache:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:snapshot:/applications/${var.application_name}/*",
-      "arn:aws:elasticache:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:usergroup:/applications/${var.application_name}/*",
-      "arn:aws:elasticache:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:subnetgroup:${var.application_name}-*"
+      "arn:aws:ec2:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:security-group/applications/${var.application_name}/*",
+      "arn:aws:ec2:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:subnet/applications/${var.application_name}/*",
+      "arn:aws:ec2:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:network-interface/applications/${var.application_name}/*",
+      "arn:aws:elasticache:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:cluster:/applications/${var.application_name}/*",
+      "arn:aws:elasticache:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:serverlesscache:/applications/${var.application_name}/*",
+      "arn:aws:elasticache:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:parametergroup:${var.application_name}-*",
+      "arn:aws:elasticache:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:serverlesscachesnapshot:/applications/${var.application_name}/*",
+      "arn:aws:elasticache:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:reserved-instance:/applications/${var.application_name}/*",
+      "arn:aws:elasticache:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:user:/applications/${var.application_name}/*",
+      "arn:aws:elasticache:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:securitygroup:/applications/${var.application_name}/*",
+      "arn:aws:elasticache:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:replicationgroup:/applications/${var.application_name}/*",
+      "arn:aws:elasticache:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:snapshot:/applications/${var.application_name}/*",
+      "arn:aws:elasticache:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:usergroup:/applications/${var.application_name}/*",
+      "arn:aws:elasticache:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:subnetgroup:${var.application_name}-*"
     ]
     actions = [
       "elasticache:RemoveTagsFromResource",

--- a/common.tf
+++ b/common.tf
@@ -3,18 +3,22 @@ data "aws_region" "current" {}
 
 variable "application_name" {
   description = "Name of the application. Will be used for naming resources"
+  type        = string
 }
 
 variable "application_role_arn" {
   description = "ARN of the IAM role used by the application"
+  type        = string
 }
 
 variable "domain_account_role" {
   description = "Role which can be assumed in another account in order to update DNS records"
+  type        = string
 }
 
 variable "project" {
   description = "Name of project (team)"
+  type        = string
 }
 
 data "aws_iam_policy_document" "secrets" {

--- a/container_app.tf
+++ b/container_app.tf
@@ -23,7 +23,7 @@ data "aws_iam_policy_document" "container0" {
     content {
       sid       = "sts0"
       effect    = "Allow"
-      resources = ["${var.domain_account_role}"]
+      resources = [var.domain_account_role]
       actions   = ["sts:AssumeRole"]
     }
   }
@@ -140,7 +140,7 @@ data "aws_iam_policy_document" "container1" {
   statement {
     sid       = "cluster0"
     effect    = "Allow"
-    resources = ["${var.container_app.ecs_cluster_arn}"]
+    resources = [var.container_app.ecs_cluster_arn]
 
     actions = [
       "ecs:UntagResource",
@@ -158,7 +158,7 @@ data "aws_iam_policy_document" "container2" {
   statement {
     sid       = "service0"
     effect    = "Allow"
-    resources = ["${var.container_app.ecs_service_arn}"]
+    resources = [var.container_app.ecs_service_arn]
     actions = [
       "ecs:UpdateService",
       "ecs:UntagResource",

--- a/container_app.tf
+++ b/container_app.tf
@@ -174,8 +174,8 @@ data "aws_iam_policy_document" "container2" {
     sid    = "secrets0"
     effect = "Allow"
     resources = [
-      "arn:aws:secretsmanager:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:secret:/${var.application_name}/*",
-      "arn:aws:secretsmanager:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:secret:/${var.application_name}/*/*"
+      "arn:aws:secretsmanager:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:secret:/${var.application_name}/*",
+      "arn:aws:secretsmanager:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:secret:/${var.application_name}/*/*"
     ]
     actions = [
       "secretsmanager:UpdateSecret",
@@ -190,7 +190,7 @@ data "aws_iam_policy_document" "container2" {
   statement {
     sid       = "secrets1"
     effect    = "Allow"
-    resources = ["arn:aws:secretsmanager:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:secret:/github/access_credentials-*"]
+    resources = ["arn:aws:secretsmanager:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:secret:/github/access_credentials-*"]
     actions   = [
       "secretsmanager:GetResourcePolicy",
       "secretsmanager:DescribeSecret",

--- a/examples/test_app/main.tf
+++ b/examples/test_app/main.tf
@@ -1,3 +1,7 @@
+provider "aws" {
+  region = "eu-central-1"
+}
+
 module "workspace_user_permissions" {
   source = "../../"
 

--- a/lambda_app.tf
+++ b/lambda_app.tf
@@ -149,7 +149,7 @@ data "aws_iam_policy_document" "lambda0" {
   statement {
     sid       = "serviceroles"
     effect    = "Allow"
-    resources = ["${var.application_role_arn}"]
+    resources = [var.application_role_arn]
     actions = [
       "iam:CreateServiceLinkedRole",
       "iam:DeleteServiceLinkedRole",

--- a/lambda_app.tf
+++ b/lambda_app.tf
@@ -122,7 +122,7 @@ data "aws_iam_policy_document" "lambda0" {
   statement {
     sid       = "logs0"
     effect    = "Allow"
-    resources = ["arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/${var.application_name}-*"]
+    resources = ["arn:aws:logs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/${var.application_name}-*"]
     actions = [
       "logs:DescribeSubscriptionFilters",
       "logs:PutSubscriptionFilter",
@@ -176,7 +176,7 @@ data "aws_iam_policy_document" "lambda1" {
     sid    = "appscalingread0"
     effect = "Allow"
     resources = [
-      "arn:aws:application-autoscaling:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:scalable-target/*"
+      "arn:aws:application-autoscaling:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:scalable-target/*"
     ]
     actions = [
       "application-autoscaling:DescribeScalableTargets",
@@ -191,7 +191,7 @@ data "aws_iam_policy_document" "lambda1" {
     effect = "Allow"
     # FIXME: We need to scope this down
     resources = [
-      "arn:aws:application-autoscaling:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:scalable-target/*"
+      "arn:aws:application-autoscaling:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:scalable-target/*"
     ]
     actions = [
       "application-autoscaling:RegisterScalableTarget",
@@ -231,7 +231,7 @@ data "aws_iam_policy_document" "lambda2" {
   statement {
     sid       = "secrets0"
     effect    = "Allow"
-    resources = ["arn:aws:secretsmanager:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:secret:api-keys/${var.application_name}/*"]
+    resources = ["arn:aws:secretsmanager:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:secret:api-keys/${var.application_name}/*"]
     actions = [
       "secretsmanager:PutSecretValue",
       "secretsmanager:PutResourcePolicy",
@@ -250,7 +250,7 @@ data "aws_iam_policy_document" "lambda2" {
     effect = "Allow"
     resources = [
       "arn:aws:lambda:*:${data.aws_caller_identity.current.account_id}:function:${var.application_name}-*",
-      "arn:aws:lambda:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:event-source-mapping:*"
+      "arn:aws:lambda:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:event-source-mapping:*"
     ]
 
     actions = [

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0.0"
+    }
+  }
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,4 +1,5 @@
 terraform {
+  required_version = ">= 1.0"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,4 @@
 terraform {
-  required_version = ">= 1.0"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0.0"
+      version = ">= 6.0, < 7.0"
     }
   }
 }


### PR DESCRIPTION
### Motivation
- Align ARN constructions with the AWS provider's `aws_region` attribute naming to avoid incorrect region interpolation. 
- Ensure compatibility with recent provider behavior by pinning the AWS provider version.

### Description
- Replaced occurrences of `data.aws_region.current.name` with `data.aws_region.current.region` across IAM policy documents in `api_app.tf`, `cdn_app.tf`, `common.tf`, `container_app.tf`, and `lambda_app.tf` to correctly interpolate region into ARNs. 
- Added `versions.tf` to require the AWS provider `~> 6.0.0` to lock provider behavior expected by these changes.

### Testing
- Ran `terraform fmt` to normalize file formatting and it completed successfully. 
- Ran `terraform validate` against the module with the updated provider constraint and the configuration validated successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dd02c387a08322be5a0d2dc2f4546e)